### PR TITLE
fix clang compilation on 64bit systems without 32bit libc headers.

### DIFF
--- a/dns-says-no/Round1/xdp_dns_says_no_kern_v1.c
+++ b/dns-says-no/Round1/xdp_dns_says_no_kern_v1.c
@@ -30,14 +30,20 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <stdint.h>
+
 #include <linux/bpf.h>
 #include <linux/if_ether.h> /* for struct ethhdr   */
 #include <linux/ip.h>       /* for struct iphdr    */
 #include <linux/ipv6.h>     /* for struct ipv6hdr  */
 #include <linux/in.h>       /* for IPPROTO_UDP     */
 #include <linux/udp.h>      /* for struct udphdr   */
-#include <string.h>         /* for memcpy() */
+
+// do not use libc includes because this causes clang 
+// to include 32bit headers on 64bit ( only ) systems.
+typedef __u8 uint8_t;
+typedef __u16 uint16_t;
+typedef __u32 uint32_t;
+#define memcpy __builtin_memcpy
 
 #define DNS_PORT      53
 #define RCODE_REFUSED  5

--- a/dns-says-no/Round2/xdp_dns_says_no_kern_v2.c
+++ b/dns-says-no/Round2/xdp_dns_says_no_kern_v2.c
@@ -30,14 +30,20 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <stdint.h>
+
 #include <linux/bpf.h>
 #include <linux/if_ether.h> /* for struct ethhdr   */
 #include <linux/ip.h>       /* for struct iphdr    */
 #include <linux/ipv6.h>     /* for struct ipv6hdr  */
 #include <linux/in.h>       /* for IPPROTO_UDP     */
 #include <linux/udp.h>      /* for struct udphdr   */
-#include <string.h>         /* for memcpy() */
+
+// do not use libc includes because this causes clang 
+// to include 32bit headers on 64bit ( only ) systems.
+typedef __u8 uint8_t;
+typedef __u16 uint16_t;
+typedef __u32 uint32_t;
+#define memcpy __builtin_memcpy
 
 #define DNS_PORT      53
 #define RCODE_REFUSED  5

--- a/dns-says-no/Round3/xdp_dns_says_no_kern_v3.c
+++ b/dns-says-no/Round3/xdp_dns_says_no_kern_v3.c
@@ -30,7 +30,7 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <stdint.h>
+
 #include <linux/bpf.h>
 #include <linux/if_ether.h> /* for struct ethhdr   */
 #include <linux/ip.h>       /* for struct iphdr    */
@@ -39,7 +39,13 @@
 #include <linux/udp.h>      /* for struct udphdr   */
 #include <bpf_helpers.h>
 #include <bpf_endian.h>
-#include <string.h>         /* for memcpy() */
+
+// do not use libc includes because this causes clang 
+// to include 32bit headers on 64bit ( only ) systems.
+typedef __u8 uint8_t;
+typedef __u16 uint16_t;
+typedef __u32 uint32_t;
+#define memcpy __builtin_memcpy
 
 #define DNS_PORT      53
 #define RR_TYPE_OPT   41


### PR DESCRIPTION
@see: https://patchwork.ozlabs.org/project/netdev/patch/151804207444.30000.12666757505388007849.stgit@firesoul/